### PR TITLE
Force-Quit patch

### DIFF
--- a/src/com/nibdev/otrtav2/view/adapters/VendorGridAdapter.java
+++ b/src/com/nibdev/otrtav2/view/adapters/VendorGridAdapter.java
@@ -49,7 +49,9 @@ public class VendorGridAdapter extends BaseAdapter implements OnNewLocalDataList
 		mSectionsList = new ArrayList<String>();
 		mSectionsStart = new ArrayList<Integer>();
 		for (int i = 0; i < mVendorData.size(); i++){
-			String vletter = mVendorData.get(i).get(DBLocal.COLUMN_NAME).toString().substring(0, 1).toUpperCase(Locale.ENGLISH);
+			String vletter = mVendorData.get(i).get(DBLocal.COLUMN_NAME).toString();
+			if (vletter == null || vletter.length() < 1) continue;
+			vletter = vletter.substring(0, 1).toUpperCase(Locale.ENGLISH);
 			if (!mSectionsList.contains(vletter)){
 				mSectionsList.add(vletter);
 				mSectionsStart.add(i);
@@ -107,8 +109,8 @@ public class VendorGridAdapter extends BaseAdapter implements OnNewLocalDataList
 
 	@Override
 	public int getSectionForPosition(int position) {
-		String letter = mVendorData.get(position).get(DBLocal.COLUMN_NAME).toString().substring(0, 1).toUpperCase(Locale.ENGLISH);
-		return mSectionsList.indexOf(letter);
+		String letter = mVendorData.get(position).get(DBLocal.COLUMN_NAME).toString();
+		return (letter == null || letter.length() < 1) ? 0 : mSectionsList.indexOf(letter.substring(0, 1).toUpperCase(Locale.ENGLISH));
 	}
 
 	@Override


### PR DESCRIPTION
Empty String Patch by Vardion (xda, url below).

Fixes force-quit when opening the app 

(Tested on my HTC One M7, android 4.4.2 kitkat)


>Well, I analyzed the crashes: apparently the online database (the one the app downloads at first start) contains a vendor with an empty vendor name.
This leads to crashes in com.nibdev.otrtav2.view.adapters.VendorGridAdapter methods createSectionData() and getSectionForPosition().
>
>In both cases, the substring(0, 1) throws an exception because it is executed for an empty string (mVendorData.get(position).get(DBLocal.COLUMN_NAME ).toString() is empty).
>
>I changed the code to skip those entries (in createSectionData) and return 0 (in getSectionForPosition). In the latter case, the correct result would be -1 (not found) instead of 0, but this makes another adapter crash and I don't feel like reworking the whole app.
The current fix is dirty, but works.
>> http://forum.xda-developers.com/showpost.php?p=64129049&postcount=47 (2015-12-28)